### PR TITLE
fix to pass request body to authorizer

### DIFF
--- a/lib/patchboard/action.rb
+++ b/lib/patchboard/action.rb
@@ -66,7 +66,7 @@ class Patchboard
         # implementations of context.authorizer
         scheme, credential = begin
           context.authorizer(@auth_schemes, resource, @name, input_options)
-        rescue
+        rescue ArgumentError
           context.authorizer(@auth_schemes, resource, @name)
         end
 

--- a/lib/patchboard/action.rb
+++ b/lib/patchboard/action.rb
@@ -59,13 +59,20 @@ class Patchboard
         :url => url, :method => @method, :headers => headers
       }
 
+      input_options = self.process_args(args)
+
       if @auth_schemes && context.respond_to?(:authorizer)
-        scheme, credential = context.authorizer(@auth_schemes, resource, @name)
+        # Ugly hack to maintain backwards compatibility with existing 
+        # implementations of context.authorizer
+        scheme, credential = begin
+          context.authorizer(@auth_schemes, resource, @name, input_options)
+        rescue
+          context.authorizer(@auth_schemes, resource, @name)
+        end
 
         headers["Authorization"] = "#{scheme} #{credential}"
       end
 
-      input_options = self.process_args(args)
       if input_options[:body]
         options[:body] = input_options[:body]
       end

--- a/lib/patchboard/action.rb
+++ b/lib/patchboard/action.rb
@@ -65,7 +65,11 @@ class Patchboard
         # Ugly hack to maintain backwards compatibility with existing 
         # implementations of context.authorizer
         scheme, credential = begin
-          context.authorizer(@auth_schemes, resource, @name, input_options)
+          context.authorizer(
+            :schemes => @auth_schemes, 
+            :resource => resource, :action => @name,
+            :request => input_options
+          )
         rescue ArgumentError
           context.authorizer(@auth_schemes, resource, @name)
         end


### PR DESCRIPTION
We have a need for using the request body in the authorizer method to do things like hashing and signing in the authorization header.
