### PR TITLE
Query params are not correctly escaped in URL

### DIFF
--- a/lib/patchboard/api.rb
+++ b/lib/patchboard/api.rb
@@ -132,7 +132,7 @@ class Patchboard
         # TODO check query schema
         keys.each do |key|
           if string = (params[key.to_s] || params[key.to_sym])
-            parts << "#{URI.escape(key.to_s)}=#{URI.escape(string)}"
+            parts << "#{CGI::escape(key.to_s)}=#{CGI::escape(string)}"
           end
         end
         if parts.size > 0


### PR DESCRIPTION
If I have a resource that takes an email query parameter and the email I am trying to pass contains a '+' it gets incorrectly escaped:

```
client.resources.user_query(:email => 'julian+test@email.com').url
=> "http://someurl.com/users?email=julian+test@email.com"
```

When the patchboard server receives the request, the email query parameter gets URL parsed to "julian test@email.com"

The problem is that URI.escape leaves characters such as '+' or '&' untouched. I've switched to using CGI::escape instead which wouldn't work for encoding a full URL, but should be fine for encoding individual query parameters.

This is the new behavior with the patch:

```
client.resources.user_query(:email => 'julian+test@email.com').url
=> "http://someurl.com/users?email=julian%2Btest%40email.com"
```

And on the server it gets correctly parsed to "julian+test@gmail.com"

Here's a pretty good discussion of the differences: http://stackoverflow.com/a/13059657
